### PR TITLE
Fix bug when adding context to a generator

### DIFF
--- a/mdc/decorators.py
+++ b/mdc/decorators.py
@@ -81,10 +81,14 @@ def wrap_function_or_generator(func, pass_context_as=None, context_dict=None):
             to_send = None
             generator = func(*args, **kwargs)
 
-            with new_log_context(**context_dict) as context:
-                to_yield = generator.send(to_send)
-
-            to_send = yield to_yield
+            while True:
+                try:
+                    with new_log_context(**context_dict) as context:
+                        to_yield = generator.send(to_send)
+                except StopIteration:
+                    return
+                else:
+                    to_send = yield to_yield
 
     else:
 

--- a/tests/mdc_tests.py
+++ b/tests/mdc_tests.py
@@ -46,6 +46,8 @@ def test_generator():
             assert_context_has(inside=True)
             yield i
 
+    assert list(my_generator()) == list(range(5))
+
     with new_log_context(inside=False):
         for _ in my_generator():
             assert_context_has(inside=False)


### PR DESCRIPTION
I did not notice this until now but actually the old decorator for a generator would only yield the first value then exit.

Added a test and the fix