### PR TITLE
Fix Python 3.12 compatibility (and remove Python 2 compatibility)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '2.7'
 - '3.4'
 install:
 - pip install .

--- a/mdc/__init__.py
+++ b/mdc/__init__.py
@@ -11,12 +11,9 @@ import logging
 import sys
 from functools import wraps
 
-from future import standard_library
 from mdc.context import *
 from mdc.decorators import *
 from pythonjsonlogger import jsonlogger
-
-standard_library.install_aliases()
 
 
 MDContext = new_log_context

--- a/mdc/context.py
+++ b/mdc/context.py
@@ -11,9 +11,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-from future import standard_library
-
-standard_library.install_aliases()
 import time
 import uuid
 import logging

--- a/mdc/decorators.py
+++ b/mdc/decorators.py
@@ -2,9 +2,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
 
-standard_library.install_aliases()
 import sys
 import inspect
 from functools import wraps

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,14 +11,12 @@ keywords = logging, mdc, context
 license_file = LICENSE.txt
 classifiers =
     Topic :: System :: Logging
-    Programming Language :: Python :: 2
     Programming Language :: Python :: 3
 
 [options]
 zip_safe = False
 packages = mdc
-install_requires = future
-                   python-json-logger
+install_requires = python-json-logger
 
 [options.package_data]
 * = *.txt, *.md, *.rst

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py2, py3
+envlist = py3
 
 [testenv]
 passenv = *


### PR DESCRIPTION
MDC uses the `future` library for compatibility with Python 2.x. The `future` library uses the `imp` library in Python which was deprecated back in Python 3.4, and removed in Python 3.12. This breaks MDC with Python 3.12:
```
.venv/lib/python3.12/site-packages/mdc/__init__.py:14: in <module>
    from future import standard_library
.venv/lib/python3.12/site-packages/future/standard_library/__init__.py:65: in <module>
    import imp
E   ModuleNotFoundError: No module named 'imp' 
```
There has been an open issue in the `future` project to stop using this deprecated module [since 2019](https://github.com/PythonCharmers/python-future/issues/488#ref-pullrequest-702982153) with an open PR, but nothing has happened in that project.

So my solution to fix Python 3.12 compatibility is to remove the dependency on `future` and remove Python 2.x compatibility. This could be a major version bump to signal the change in compatible Python versions.